### PR TITLE
Auto-close issue after event PR merge

### DIFF
--- a/.github/scripts/process_event_issue.py
+++ b/.github/scripts/process_event_issue.py
@@ -144,7 +144,8 @@ def main():
                     f"- Title: {event_data['event_title']}\n"
                     f"- Date: {event_data['event_date']}\n"
                     f"- Location: {event_data['location']}\n"
-                    f"- Community: {event_data['community']}"
+                    f"- Community: {event_data['community']}\n\n"
+                    f"Closes #{issue_number}"
                 ),
                 head=branch_name,
                 base='main'


### PR DESCRIPTION
Add 'Closes #issue_number' keyword to PR body so GitHub automatically closes the source issue when the PR is merged.