### PR TITLE
Renomme Apéro Web en Apéro IA Bordeaux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cette page permet de retrouver l'ensemble des communautés et d'accéder à notr
 
 ### Afterworks
 
-- [Apéro Web](apero-web/)
+- [Apéro IA Bordeaux](apero-web/)
 - [DigitalNights](digitalnights/)
 
 ### Conférences

--- a/apero-web/README.md
+++ b/apero-web/README.md
@@ -1,14 +1,15 @@
-# Apéro Web ![Logo](./logo-apero-web-bdx.jpeg ':size=100')
+# Apéro IA Bordeaux ![Logo](./logo-apero-web-bdx.jpeg ':size=100')
 
-🍷🍺 L'Apéro Web Bordeaux c'est l'afterwork convivial réunissant toutes les personnes qui font la tech bordelaise :
-Entrepreneurs, CEO, CTO, Devs, PO, PM, UX/UI, SEO, SEM, CM, SRE, DA, DevOps, growth hackers etc...
-Si votre métier à un rapport avec le web ou la tech, cet apéro est fait pour vous !
+🍷🤖 L'Apéro IA Bordeaux, c'est l'afterwork convivial pour se retrouver autour d'un verre et échanger sur tous les usages de l'intelligence artificielle.
+Que vous utilisiez ChatGPT au quotidien, développiez des outils fondés sur l'IA ou souhaitiez simplement découvrir le sujet, vous y trouverez des personnes avec qui échanger, partager et apprendre.
 
 A chaque évènement un bar bordelais différent !
 
 🌍 Sites web : 
 
-[Meetup](https://www.meetup.com/fr-FR/apero-web-bordeaux/)
+[Meetup](https://www.meetup.com/fr-FR/apero-ia-bordeaux/)
+
+[LinkedIn](https://www.linkedin.com/company/apero-ia-bordeaux/)
 
 [Facebook](https://www.facebook.com/aperowebbdx/)
 

--- a/apero-web/events_src.json
+++ b/apero-web/events_src.json
@@ -4,5 +4,5 @@
     "past"
   ],
   "type": "meetup",
-  "url": "https://www.meetup.com/fr-FR/apero-web-bordeaux/"
+  "url": "https://www.meetup.com/fr-FR/apero-ia-bordeaux/"
 }


### PR DESCRIPTION
## Résumé

- renomme la communauté en « Apéro IA Bordeaux » dans l’annuaire et sa page dédiée ;
- actualise la présentation pour refléter le positionnement autour des usages de l’intelligence artificielle ;
- remplace les liens Meetup et LinkedIn par leurs URL canoniques actuelles ;
- met à jour la source Meetup utilisée par la synchronisation automatique.

## Compatibilité

Le dossier technique `apero-web` et l’URL du calendrier iCal sont conservés afin de ne pas casser les liens et abonnements existants. Les titres des événements passés restent inchangés pour préserver l’historique.

## Vérifications

- `git diff --check`
- validation JSON de `apero-web/events_src.json`